### PR TITLE
#285 - Add Netlify Cache

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -13,6 +13,12 @@ module.exports = {
   plugins: [
     'gatsby-plugin-styled-components',
     {
+      resolve: 'gatsby-plugin-netlify-cache',
+      options: {
+          cachePublic: true,
+      }
+    },
+    {
       resolve: `gatsby-source-filesystem`,
       options: {
         path: `${__dirname}/content/blog`,

--- a/package-lock.json
+++ b/package-lock.json
@@ -8144,6 +8144,27 @@
         "sharp": "^0.23.2"
       }
     },
+    "gatsby-plugin-netlify-cache": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-netlify-cache/-/gatsby-plugin-netlify-cache-1.2.0.tgz",
+      "integrity": "sha512-unt4mAVpC0JzwZSo8KQV4P/trDHkr3PeTWDF5Hijw9jGfNQIWXbcj9nYljAVg7HCich6E6b27Q+zuf53InwpDQ==",
+      "requires": {
+        "babel-runtime": "^6.26.0",
+        "fs-extra": "^7.0.0"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+          "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        }
+      }
+    },
     "gatsby-plugin-offline": {
       "version": "2.2.10",
       "resolved": "https://registry.npmjs.org/gatsby-plugin-offline/-/gatsby-plugin-offline-2.2.10.tgz",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "gatsby-plugin-feed": "^2.0.8",
     "gatsby-plugin-google-analytics": "^2.1.1",
     "gatsby-plugin-manifest": "^2.0.5",
+    "gatsby-plugin-netlify-cache": "^1.2.0",
     "gatsby-plugin-offline": "^2.0.5",
     "gatsby-plugin-react-helmet": "^3.0.0",
     "gatsby-plugin-sharp": "^2.2.1",


### PR DESCRIPTION
This plugin is supposed to help with netlify build times.

Trying the optional parameter of `cachePublic` - will need to monitor the directory size to make sure it doesn't overwhelm `netlify`. 