### PR TITLE
fix: selection should be global

### DIFF
--- a/src/stylesheets/code.css
+++ b/src/stylesheets/code.css
@@ -6,7 +6,6 @@ Allow inline code blocks to break
     white-space: normal;
 }
 
-
 /*
     Custom Styling Of Code Titles
   --------------------------------------------- */

--- a/src/stylesheets/global.css
+++ b/src/stylesheets/global.css
@@ -74,6 +74,11 @@ img::-moz-selection {
   background: transparent;
 }
 
+*::selection {
+    background: rgba(255, 109, 91, 0.99);
+    text-shadow: none;
+}
+
 /*
     BASE TYPOGRAPHY
   --------------------------------------------- */
@@ -317,10 +322,4 @@ th:first-child {
   }
 }
 
-/*
-    SELECTION STYLES
-  --------------------------------------------- */
-* + ::selection {
-    background: rgba(255, 109, 91, 0.99);
-    text-shadow: none;
-}
+


### PR DESCRIPTION
the *+::selection was a typo. It was selecting _adjacent_ to everything.
This resulted in undesireable behavior.

For example, the first paragraph would have a different highlighting structure.

If there was italicized or bold text in the first paragraph, they'd also be different.

This fixes that _without_ being overly specific, allowing code blocks to retain their style.