### PR TITLE
Publish notes

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -255,7 +255,7 @@ exports.createPages = ({ graphql, actions }) => {
                 path: note.node.frontmatter.slug || note.node.fields.filePath,
                 component: entryTemplate,
                 context: {
-                    slug: note.node.fields.slug,
+                    slug: note.node.frontmatter.slug,
                     previous: null,
                     next: null,
                 },

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -9,6 +9,7 @@ const {
     publishYear,
 } = require('./src/utils/dateFns')
 const entryTemplate = path.resolve(`./src/templates/BlogEntry.js`)
+const notesTemplate = path.resolve(`./src/templates/NotesEntry.js`)
 const entryList = path.resolve(`./src/templates/BlogList.js`)
 const bookTemplate = path.resolve(`./src/templates/BookReview.js`)
 const tagTemplate = path.resolve(`./src/templates/TagList.js`)
@@ -220,10 +221,10 @@ exports.createPages = ({ graphql, actions }) => {
         // Create blog posts pages.
         posts.forEach((post, index) => {
             const { redirectTarget, slug } = post.node.fields
-            const { slug: fmSlug } = post.node.frontmatter
+            const { slug: frontmatterSlug } = post.node.frontmatter
             createRedirect({
                 fromPath: `/${slug}`,
-                toPath: fmSlug || redirectTarget,
+                toPath: frontmatterSlug || redirectTarget,
                 isPermanent: true,
                 redirectInBrowser: true,
                 statusCode: 301,
@@ -233,10 +234,10 @@ exports.createPages = ({ graphql, actions }) => {
                 index === posts.length - 1 ? null : posts[index + 1].node
             const next = index === 0 ? null : posts[index - 1].node
             createPage({
-                path: fmSlug || redirectTarget,
+                path: frontmatterSlug || redirectTarget,
                 component: entryTemplate,
                 context: {
-                    slug: slug,
+                    slug,
                     previous,
                     next,
                 },
@@ -246,16 +247,20 @@ exports.createPages = ({ graphql, actions }) => {
         // Notes------------------------------------------->
         const notes = result.data.notes.edges
         notes.forEach((note, index) => {
+            const { slug } = note.node.frontmatter
             // ! TODO: fix the template re: previous/next
             // const previous =
             //     index === notes.length - 1 && Boolean(note[index+1]) ? null : note[index + 1].node
             // const next = index === 0  && Boolean(note[index-1]) ? null : note[index - 1].node
-
+            if (!slug)
+                throw new Error(
+                    `Published note does not have a slug - fix this in content\n${note}`
+                )
             createPage({
-                path: note.node.frontmatter.slug || note.node.fields.filePath,
-                component: entryTemplate,
+                path: slug,
+                component: notesTemplate,
                 context: {
-                    slug: note.node.frontmatter.slug,
+                    slug: slug,
                     previous: null,
                     next: null,
                 },

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -185,8 +185,37 @@ exports.createPages = ({ graphql, actions }) => {
         // Blog ------------------------------------------->
         const posts = result.data.blog.edges
 
+        // Create blog posts pages.
+        posts.forEach((post, index) => {
+            const { redirectTarget, slug } = post.node.fields
+            const { slug: frontmatterSlug } = post.node.frontmatter
+            createRedirect({
+                fromPath: `/${slug}`,
+                toPath: frontmatterSlug || redirectTarget,
+                isPermanent: true,
+                redirectInBrowser: true,
+                statusCode: 301,
+            })
+
+            const previous =
+                index === posts.length - 1 ? null : posts[index + 1].node
+            const next = index === 0 ? null : posts[index - 1].node
+            createPage({
+                path: frontmatterSlug || redirectTarget,
+                component: entryTemplate,
+                context: {
+                    slug,
+                    previous,
+                    next,
+                },
+            })
+        })
+
+        // Notes------------------------------------------->
+        const notes = result.data.notes.edges
+
         // Create blog list pages
-        const BLOG_PAGE_TOTAL = Math.ceil(posts.length / ENTRIES_PER_PAGE) - 1 // minus one because we start @ 0.
+        const BLOG_PAGE_TOTAL = Math.ceil(notes.length / ENTRIES_PER_PAGE) - 1 // minus one because we start @ 0.
         let currentPage = BLOG_PAGE_TOTAL
         while (currentPage >= 0) {
             const path =
@@ -217,35 +246,6 @@ exports.createPages = ({ graphql, actions }) => {
 
             currentPage -= 1
         }
-
-        // Create blog posts pages.
-        posts.forEach((post, index) => {
-            const { redirectTarget, slug } = post.node.fields
-            const { slug: frontmatterSlug } = post.node.frontmatter
-            createRedirect({
-                fromPath: `/${slug}`,
-                toPath: frontmatterSlug || redirectTarget,
-                isPermanent: true,
-                redirectInBrowser: true,
-                statusCode: 301,
-            })
-
-            const previous =
-                index === posts.length - 1 ? null : posts[index + 1].node
-            const next = index === 0 ? null : posts[index - 1].node
-            createPage({
-                path: frontmatterSlug || redirectTarget,
-                component: entryTemplate,
-                context: {
-                    slug,
-                    previous,
-                    next,
-                },
-            })
-        })
-
-        // Notes------------------------------------------->
-        const notes = result.data.notes.edges
         notes.forEach((note, index) => {
             const { slug } = note.node.frontmatter
             // ! TODO: fix the template re: previous/next

--- a/src/components/BlogExcerpt.jsx
+++ b/src/components/BlogExcerpt.jsx
@@ -15,21 +15,21 @@ const RightAdjustDiv = styled.div`
 `
 
 export function BlogExcerpt({ node }) {
-    const { title, slug } = node.frontmatter
-    const { listDate, slug: fieldSlug, readingTime } = node.fields
+    const { title, slug, publish } = node.frontmatter
+    const { readingTime } = node.fields
     const { words: wordCount, text: estimate } = readingTime
     const { excerpt } = node
     return (
         <ContentWrapper>
-            <PostTitleLink slug={`/${slug ?? fieldSlug}`} title={title} />
+            <PostTitleLink slug={`/${slug}`} title={title} />
             <PostDetails
-                date={listDate}
+                date={publish}
                 estimate={estimate}
                 wordCount={wordCount}
             />
             <Blurb content={excerpt} />
             <RightAdjustDiv>
-                <Link to={`/${slug ?? fieldSlug}`}>&#10149;{`Read more`}</Link>
+                <Link to={`/${slug}`}>&#10149;{`Read more`}</Link>
             </RightAdjustDiv>
         </ContentWrapper>
     )

--- a/src/components/BlogExcerpt.jsx
+++ b/src/components/BlogExcerpt.jsx
@@ -15,13 +15,13 @@ const RightAdjustDiv = styled.div`
 `
 
 export function BlogExcerpt({ node }) {
-    const { title } = node.frontmatter
-    const { listDate, slug, readingTime } = node.fields
+    const { title, slug } = node.frontmatter
+    const { listDate, slug: fieldSlug, readingTime } = node.fields
     const { words: wordCount, text: estimate } = readingTime
     const { excerpt } = node
     return (
         <ContentWrapper>
-            <PostTitleLink slug={`/${slug}`} title={title} />
+            <PostTitleLink slug={`/${slug ?? fieldSlug}`} title={title} />
             <PostDetails
                 date={listDate}
                 estimate={estimate}
@@ -29,7 +29,7 @@ export function BlogExcerpt({ node }) {
             />
             <Blurb content={excerpt} />
             <RightAdjustDiv>
-                <Link to={`/${slug}`}>&#10149;{`Read more`}</Link>
+                <Link to={`/${slug ?? fieldSlug}`}>&#10149;{`Read more`}</Link>
             </RightAdjustDiv>
         </ContentWrapper>
     )

--- a/src/components/PostDetails.jsx
+++ b/src/components/PostDetails.jsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import styled from 'styled-components'
+import dayjs from 'dayjs'
 
 export const Details = styled.p`
     display: inline;
@@ -14,8 +15,12 @@ export const DetailsWrapper = styled.div`
 export function PostDetails({ date, estimate, wordCount }) {
     return (
         <DetailsWrapper>
-            <Details>{date}</Details>
-            &nbsp;|&nbsp;
+            {dayjs(date).isValid() && (
+                <>
+                    <Details>{dayjs(date).format('YYYY-MM-DD')}</Details>
+                    &nbsp;|&nbsp;
+                </>
+            )}
             <Details>~{estimate}</Details>
             &nbsp;|&nbsp;
             <Details>{wordCount} words</Details>

--- a/src/pages/lists.jsx
+++ b/src/pages/lists.jsx
@@ -14,10 +14,13 @@ function Lists(props) {
             <ColumnLinkWrapper>
                 <ul>
                     {list.map(({ node }) => {
-                        const { title } = node.frontmatter
-                        const { slug } = node.fields
+                        const { title, slug } = node.frontmatter
+                        const { slug: fieldSlug } = node.fields
                         return (
-                            <ListedLink key={slug} to={slug}>
+                            <ListedLink
+                                key={slug ?? fieldSlug}
+                                to={`/${slug ?? fieldSlug}`}
+                            >
                                 {title.toLowerCase()}
                             </ListedLink>
                         )
@@ -34,8 +37,10 @@ export default Lists
 export const pageQuery = graphql`
     query {
         lists: allMarkdownRemark(
-            filter: { fields: { sourceInstance: { eq: "list" } } }
-            sort: { fields: frontmatter___title }
+            filter: {
+                frontmatter: { category: { in: ["lists"] } }
+                fields: { sourceInstance: { eq: "notes" } }
+            }
         ) {
             edges {
                 node {
@@ -46,6 +51,7 @@ export const pageQuery = graphql`
                     }
                     frontmatter {
                         title
+                        slug
                     }
                 }
             }

--- a/src/templates/BlogList.js
+++ b/src/templates/BlogList.js
@@ -27,7 +27,6 @@ const SearchLink = styled(NavLink)`
     :hover {
         &:before {
             content: '🔎 ';
-
         }
     }
 `
@@ -69,7 +68,7 @@ export const pageQuery = graphql`
             filter: {
                 fields: {
                     isPublished: { eq: true }
-                    sourceInstance: { eq: "blog" }
+                    sourceInstance: { eq: "notes" }
                 }
             }
             sort: { order: [DESC], fields: [fields___listDate] }
@@ -89,6 +88,7 @@ export const pageQuery = graphql`
                     }
                     frontmatter {
                         title
+                        slug
                     }
                 }
             }

--- a/src/templates/BlogList.js
+++ b/src/templates/BlogList.js
@@ -36,7 +36,6 @@ function BlogList(props) {
     const { previousPage, nextPage } = props.pageContext
     const { title } = useSiteMetadata()
     const posts = data.allMarkdownRemark.edges
-
     return (
         <Layout>
             <SEO
@@ -67,11 +66,13 @@ export const pageQuery = graphql`
         allMarkdownRemark(
             filter: {
                 fields: {
-                    isPublished: { eq: true }
                     sourceInstance: { eq: "notes" }
+                    isPrivate: { ne: true }
+                    stage: { eq: "published" }
                 }
+                frontmatter: { private: { ne: true } }
             }
-            sort: { order: [DESC], fields: [fields___listDate] }
+            sort: { fields: [fields___publishDate], order: DESC }
             limit: $limit
             skip: $skip
         ) {
@@ -80,7 +81,7 @@ export const pageQuery = graphql`
                     excerpt(format: PLAIN)
                     fields {
                         slug
-                        listDate
+                        isPublished
                         readingTime {
                             words
                             text
@@ -89,6 +90,7 @@ export const pageQuery = graphql`
                     frontmatter {
                         title
                         slug
+                        publish
                     }
                 }
             }

--- a/src/templates/NotesEntry.js
+++ b/src/templates/NotesEntry.js
@@ -1,0 +1,106 @@
+import React from 'react'
+import { graphql } from 'gatsby'
+import styled, { css } from 'styled-components'
+import {
+    Bio,
+    Layout,
+    PostDetails,
+    PostNavigation,
+    SEO,
+    PostTitle,
+} from '../components'
+
+const classicFirstLetterStyle = css`
+    float: left;
+    font-size: 3.5em;
+    font-weight: bold;
+    margin: 0 0.2em 0 0;
+    line-height: 0.75;
+`
+
+const modernFirstLetterStyle = css`
+    initial-letter: 3 2;
+`
+
+const Entry = styled.div`
+    padding: 0 0.5em;
+
+    & > p:first-of-type::first-letter {
+        color: rgb(70, 70, 70);
+        font-family: Georgia, serif;
+        text-transform: lowercase;
+        @supports not (initial-letter: 1 and -webkit-initial-letter: 1) {
+            ${classicFirstLetterStyle}
+        }
+
+        @supports (initial-letter: 1) or (-webkit-initial-letter: 1) {
+            ${modernFirstLetterStyle}
+        }
+    }
+`
+
+const PostHeaderBlock = styled.div`
+    display: flex;
+    flex-direction: column;
+    margin: 0 0 2rem 0;
+    padding: 0;
+`
+
+function EntryTemplate(props) {
+    const entry = props.data.markdownRemark
+    const { previous, next } = props.pageContext
+    const { title, tags, category } = entry.frontmatter
+    const { listDate, readingTime } = entry.fields
+    const { text: estimate, words: wordCount } = readingTime
+    return (
+        <Layout>
+            <SEO title={title} description={entry.excerpt} />
+            <PostHeaderBlock>
+                <PostTitle title={title} />
+                <PostDetails
+                    date={listDate}
+                    estimate={estimate}
+                    wordCount={wordCount}
+                />
+            </PostHeaderBlock>
+            <Entry
+                className={'entry'}
+                dangerouslySetInnerHTML={{ __html: entry.html }}
+            />
+            <hr />
+            <Bio />
+            <PostNavigation previous={previous} next={next} />
+        </Layout>
+    )
+}
+
+export default EntryTemplate
+
+export const pageQuery = graphql`
+    query NoteEntryBySlug($slug: String!) {
+        site {
+            siteMetadata {
+                title
+                author
+            }
+        }
+        markdownRemark(frontmatter: { slug: { eq: $slug } }) {
+            id
+            html
+            frontmatter {
+                title
+                date
+                publish
+                tags
+                category
+            }
+            fields {
+                listDate
+                readingTime {
+                    text
+                    words
+                }
+            }
+        }
+    }
+`

--- a/src/templates/NotesEntry.js
+++ b/src/templates/NotesEntry.js
@@ -49,8 +49,8 @@ const PostHeaderBlock = styled.div`
 function EntryTemplate(props) {
     const entry = props.data.markdownRemark
     const { previous, next } = props.pageContext
-    const { title, tags, category } = entry.frontmatter
-    const { listDate, readingTime } = entry.fields
+    const { title, publish } = entry.frontmatter
+    const { readingTime } = entry.fields
     const { text: estimate, words: wordCount } = readingTime
     return (
         <Layout>
@@ -58,7 +58,7 @@ function EntryTemplate(props) {
             <PostHeaderBlock>
                 <PostTitle title={title} />
                 <PostDetails
-                    date={listDate}
+                    date={publish}
                     estimate={estimate}
                     wordCount={wordCount}
                 />

--- a/src/utils/dateFns.js
+++ b/src/utils/dateFns.js
@@ -2,57 +2,59 @@ const dayjs = require('dayjs')
 const { BUILD_TIME, FAKE_START } = require('../constants')
 
 function isPublished(node) {
-  const { publish, date } = node.frontmatter
-  if (process.env.nofilter) {
-    return true
-  }
-  return BUILD_TIME.isAfter(publish ? dayjs(publish) : dayjs(date))
+    const { publish, date, stage } = node.frontmatter
+    if (process.env.nofilter) {
+        return true
+    }
+
+    return (
+        stage === 'published' &&
+        BUILD_TIME.isAfter(publish ? dayjs(publish) : dayjs(date))
+    )
 }
 
 function publishDate(node) {
-  const { publish, date } = node.frontmatter
-  return publish ? publish : date
+    const { publish, date } = node.frontmatter
+    return publish ? publish : date
 }
 
 function publishMonth(node) {
-  return dayjs(publishDate(node))
-    .set('date', 1)
-    .format('YYYY-MM-DD')
+    return dayjs(publishDate(node)).set('date', 1).format('YYYY-MM-DD')
 }
 
 function publishYear(node) {
-  return dayjs(publishDate(node))
-    .set('date', 1)
-    .set('month', 1)
-    .format('YYYY-MM-DD')
+    return dayjs(publishDate(node))
+        .set('date', 1)
+        .set('month', 1)
+        .format('YYYY-MM-DD')
 }
 
 const reducerToMostRecentDateBeforeBuild = (accumulator, curVal) =>
-  curVal &&
-  dayjs(curVal).isAfter(dayjs(accumulator)) &&
-  (BUILD_TIME.isAfter(curVal) || BUILD_TIME.isSame(curVal, 'day'))
-    ? curVal
-    : accumulator
+    curVal &&
+    dayjs(curVal).isAfter(dayjs(accumulator)) &&
+    (BUILD_TIME.isAfter(curVal) || BUILD_TIME.isSame(curVal, 'day'))
+        ? curVal
+        : accumulator
 
 function listDate(node) {
-  const { updated, publish, date } = node.frontmatter
-  const allDates = []
-  if (updated) allDates.push(...updated)
-  allDates.push(publish, date)
-  const filteredDates = allDates.filter(day => day)
+    const { updated, publish, date } = node.frontmatter
+    const allDates = []
+    if (updated) allDates.push(...updated)
+    allDates.push(publish, date)
+    const filteredDates = allDates.filter((day) => day)
 
-  const maxDate = filteredDates
-    .map(day => dayjs(day))
-    .reduce(reducerToMostRecentDateBeforeBuild, FAKE_START)
-  const returnedDate = maxDate && maxDate.isAfter(FAKE_START) ? maxDate : null
-  return dayjs(returnedDate).format('YYYY-MM-DD')
+    const maxDate = filteredDates
+        .map((day) => dayjs(day))
+        .reduce(reducerToMostRecentDateBeforeBuild, FAKE_START)
+    const returnedDate = maxDate && maxDate.isAfter(FAKE_START) ? maxDate : null
+    return dayjs(returnedDate).format('YYYY-MM-DD')
 }
 
 // Need to use module.exports because this is used in node, not just frontend
 module.exports = {
-  isPublished,
-  listDate,
-  publishDate,
-  publishMonth,
-  publishYear,
+    isPublished,
+    listDate,
+    publishDate,
+    publishMonth,
+    publishYear,
 }


### PR DESCRIPTION
Fixes quite a few small bugs that have persisted since the switch over to submodules and a flat content structure.

The blog list now shows the `notes` rather than a legacy `blog` content. 

Minor fixes around the edges for _what_ is displayed too (e.g., publish date instead of my convoluted calculated `listDate` field which can now be deprecated and phased out)