### PR TITLE
Fix header

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -13,17 +13,11 @@ const SiteHeader = styled.header`
 `
 
 const ContainerHeader = styled.div`
-    display: grid;
-    grid-template-columns: repeat(2, 1fr);
-
-    grid-template-areas: '
-        logo links
-    ';
-
-    justify-content: space-between;
-
+    display: flex;
+    justify-content: center;
+    flex-direction: column;
     @media screen and (min-width: 40rem) {
-        min-width: 40rem;
+        flex-direction: row;
     }
 `
 

--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -34,8 +34,10 @@ export function Layout({ children }) {
     const { menuOptions } = useSiteMetadata()
     return (
         <Paper>
-            <Header menuOptions={menuOptions} />
-            <Wrapper>{children}</Wrapper>
+            <Wrapper>
+                <Header menuOptions={menuOptions} />
+                {children}
+            </Wrapper>
             <Footer>
                 © {new Date().getFullYear()}&nbsp; Built with ❤️ using&nbsp;
                 <a href="https://www.gatsbyjs.org">Gatsby</a>


### PR DESCRIPTION
Ultimately, a pretty minor change, but the links are now "locked" to the right half of the header.

**Before**

<img width="721" alt="Screen Shot 2020-12-12 at 12 33 07 PM" src="https://user-images.githubusercontent.com/39878535/101992070-4072b980-3c76-11eb-99ef-6c68943bb29c.png">

<img width="852" alt="Screen Shot 2020-12-12 at 12 45 53 PM" src="https://user-images.githubusercontent.com/39878535/101992329-01ddfe80-3c78-11eb-8201-da9a57534476.png">


**After**

<img width="852" alt="Screen Shot 2020-12-12 at 12 44 55 PM" src="https://user-images.githubusercontent.com/39878535/101992305-df4be580-3c77-11eb-86e9-dfae0f8e597f.png">

<img width="852" alt="Screen Shot 2020-12-12 at 12 44 53 PM" src="https://user-images.githubusercontent.com/39878535/101992304-deb34f00-3c77-11eb-8da3-f89dce5384c7.png">